### PR TITLE
feat: add fzf with fzf-tab completion

### DIFF
--- a/.chezmoidata.toml
+++ b/.chezmoidata.toml
@@ -1,2 +1,3 @@
 proto_version = "0.57.2"
 starship_version = "v1.25.1"
+fzf_version = "0.73.1"

--- a/dot_zsh/fzf.zsh
+++ b/dot_zsh/fzf.zsh
@@ -1,0 +1,4 @@
+# 🔍 fzf integration (keybindings + completion)
+if command -v fzf >/dev/null 2>&1; then
+  source <(fzf --zsh)
+fi

--- a/dot_zsh/plugins.zsh
+++ b/dot_zsh/plugins.zsh
@@ -1,4 +1,11 @@
 # 🧩 Load plugins
+
+# Required by fzf-tab; fast-syntax-highlighting must load after.
+autoload -Uz compinit && compinit
+
 zinit light agkozak/zsh-z
+zinit light Aloxaf/fzf-tab
 zinit light zdharma-continuum/fast-syntax-highlighting
-zinit light zdharma-continuum/history-search-multi-word
+
+# Let fzf-tab fully own the completion menu (recommended in fzf-tab README)
+zstyle ':completion:*' menu no

--- a/run_onchange_before_install-fzf.sh.tmpl
+++ b/run_onchange_before_install-fzf.sh.tmpl
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="{{ .fzf_version }}"
+
+installed="$(fzf --version 2>/dev/null | awk '{print $1}' || true)"
+if [ "$installed" = "$version" ]; then
+  exit 0
+fi
+
+arch="$(dpkg --print-architecture)"
+
+mkdir -p "$HOME/.local/bin"
+curl -fsSL "https://github.com/junegunn/fzf/releases/download/v${version}/fzf-${version}-linux_${arch}.tar.gz" \
+  | tar -xz -C "$HOME/.local/bin" fzf


### PR DESCRIPTION
Pinned fzf binary installer + zsh integration.

- `.chezmoidata.toml`: pin `fzf_version = "0.73.1"`
- `run_onchange_before_install-fzf.sh.tmpl`: download fzf to `~/.local/bin` (matches proto/starship pattern)
- `dot_zsh/fzf.zsh`: `source <(fzf --zsh)` — Ctrl+R / Ctrl+T / Alt+C
- `dot_zsh/plugins.zsh`: add `compinit` + `Aloxaf/fzf-tab`, drop `history-search-multi-word`