### PR TITLE
feat: pull muah theme via chezmoi externals

### DIFF
--- a/.chezmoidata.toml
+++ b/.chezmoidata.toml
@@ -1,3 +1,4 @@
 proto_version = "0.57.2"
 starship_version = "v1.25.1"
 fzf_version = "0.73.1"
+muah_ref = "8f6915eb895e7fd8db5bee46f388ee6db5a9c596"

--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -1,0 +1,13 @@
+# 💋 muah theme ports, fetched from Trugamr/muah and pinned via .chezmoidata.toml
+
+[".config/fzf/muah.opts"]
+    type = "file"
+    url = "https://raw.githubusercontent.com/Trugamr/muah/{{ .muah_ref }}/ports/fzf/muah.opts"
+
+[".config/tmux/muah.conf"]
+    type = "file"
+    url = "https://raw.githubusercontent.com/Trugamr/muah/{{ .muah_ref }}/ports/tmux/muah.tmux.conf"
+
+[".config/zsh/muah.zsh"]
+    type = "file"
+    url = "https://raw.githubusercontent.com/Trugamr/muah/{{ .muah_ref }}/ports/zsh/muah.zsh"

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -22,3 +22,6 @@ bind-key h split-window -v
 
 # Config reload command
 bind-key r source-file ~/.tmux.conf \; display-message "~/.tmux.conf reloaded."
+
+# 💋 muah color theme (managed by chezmoi externals)
+source-file ~/.config/tmux/muah.conf

--- a/dot_zsh/theme.zsh
+++ b/dot_zsh/theme.zsh
@@ -1,0 +1,7 @@
+# 💋 muah theme wiring (files fetched via chezmoi externals)
+
+# fzf reads its color theme from this opts file
+export FZF_DEFAULT_OPTS_FILE="$HOME/.config/fzf/muah.opts"
+
+# fast-syntax-highlighting palette — must be sourced AFTER fsh loads (plugins.zsh)
+[ -r "$HOME/.config/zsh/muah.zsh" ] && source "$HOME/.config/zsh/muah.zsh"


### PR DESCRIPTION
## Summary
- Declare fzf/tmux/zsh ports from [Trugamr/muah](https://github.com/Trugamr/muah) as chezmoi externals in `.chezmoiexternal.toml.tmpl`, pinned via `muah_ref` in `.chezmoidata.toml` (same pattern as `proto_version` / `starship_version` / `fzf_version`).
- Wire the fetched files in: `source-file ~/.config/tmux/muah.conf` in `dot_tmux.conf`, plus a new `dot_zsh/theme.zsh` that sets `FZF_DEFAULT_OPTS_FILE` and sources the fsh palette after `plugins.zsh` has loaded `fast-syntax-highlighting`.
- Muah stays the single source of truth — bump `muah_ref` (or copy a port file into the source tree if you want a local override) to update.

## Test plan
- [x] `chezmoi update` (or `chezmoi apply --refresh-externals`) writes `~/.config/{fzf/muah.opts, tmux/muah.conf, zsh/muah.zsh}`
- [x] `tmux source-file ~/.tmux.conf` → status bar uses muah pink/grey
- [x] `exec zsh` → fast-syntax-highlighting renders keywords pink, commands green, paths sky blue
- [x] `Ctrl+R` shows fzf with muah colors (requires fzf ≥ 0.42 for `FZF_DEFAULT_OPTS_FILE`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)